### PR TITLE
Fix library name and path on some 64bit systems

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,20 +29,16 @@ set(libswiftnav_SRCS
   single_diff.c
 )
 
-if (CMAKE_CROSSCOMPILING)
-  set(LIB_SUFFIX "-${CMAKE_SYSTEM_PROCESSOR}")
-endif (CMAKE_CROSSCOMPILING)
-
-add_library(swiftnav-static${LIB_SUFFIX} STATIC ${libswiftnav_SRCS})
-target_link_libraries(swiftnav-static${LIB_SUFFIX} cblas)
-target_link_libraries(swiftnav-static${LIB_SUFFIX} lapacke)
-install(TARGETS swiftnav-static${LIB_SUFFIX} DESTINATION lib)
+add_library(swiftnav-static STATIC ${libswiftnav_SRCS})
+target_link_libraries(swiftnav-static cblas)
+target_link_libraries(swiftnav-static lapacke)
+install(TARGETS swiftnav-static DESTINATION lib${LIB_SUFFIX})
 
 if(BUILD_SHARED_LIBS)
-  add_library(swiftnav${LIB_SUFFIX} SHARED ${libswiftnav_SRCS})
-  target_link_libraries(swiftnav${LIB_SUFFIX} cblas)
-  target_link_libraries(swiftnav${LIB_SUFFIX} lapacke)
-  install(TARGETS swiftnav${LIB_SUFFIX} DESTINATION lib)
+  add_library(swiftnav SHARED ${libswiftnav_SRCS})
+  target_link_libraries(swiftnav cblas)
+  target_link_libraries(swiftnav lapacke)
+  install(TARGETS swiftnav DESTINATION lib${LIB_SUFFIX})
 else(BUILD_SHARED_LIBS)
   message(STATUS "Not building shared libraries")
 endif(BUILD_SHARED_LIBS)


### PR DESCRIPTION
Sorry, one more fix, static library installation path was not used LIB_SUFFIX

I have updated the behaviour as you suggested. This resolves the problem and keep the property you desire.

I does not use cross-compiling now, but want in future and this behaviour with ARCH_SUFFIX makes linking a bit complicated (when library is crosscompiled but application is build natively, there must be guess algorithm for library name trying both -lswiftnav nad -lswiftnav-SOMETHING). Would you like to please consider removing this feature?

PS: Please do not use patch from fix_64-01, it contains bug for crosscompiling (resets LIB_SUFFIX value). I would happily make another patch, if you want .
