### PR TITLE
Add carrier phase adjustment api for alias lock detector corrections

### DIFF
--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Swift Navigation Inc.
+ * Copyright (C) 2012,2016 Swift Navigation Inc.
  * Contact: Fergus Noble <fergus@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -212,6 +212,7 @@ void aided_tl_retune(aided_tl_state_t *s, float loop_freq,
                      float carr_freq_b1);
 
 void aided_tl_update(aided_tl_state_t *s, correlation_t cs[3]);
+void aided_tl_adjust(aided_tl_state_t *s, float err);
 
 void comp_tl_init(comp_tl_state_t *s, float loop_freq,
                     float code_freq, float code_bw,

--- a/python/swiftnav/track.pxd
+++ b/python/swiftnav/track.pxd
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Swift Navigation Inc.
+# Copyright (C) 2015,2016 Swift Navigation Inc.
 #
 # This source is subject to the license found in the file 'LICENSE' which must
 # be be distributed together with this source. All other rights reserved.
@@ -91,6 +91,7 @@ cdef extern from "libswiftnav/track.h":
                        float carr_bw, float carr_zeta, float carr_k,
                        float carr_freq_b1)
   void aided_tl_update(aided_tl_state_t *s, correlation_t cs[3])
+  void aided_tl_adjust(aided_tl_state_t *s, float err)
 
   # Tracking loop: Comp
   ctypedef struct comp_tl_state_t:

--- a/python/swiftnav/track.pyx
+++ b/python/swiftnav/track.pyx
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Swift Navigation Inc.
+# Copyright (C) 2015,2016 Swift Navigation Inc.
 #
 # This source is subject to the license found in the file 'LICENSE' which must
 # be be distributed together with this source. All other rights reserved.
@@ -311,6 +311,9 @@ cdef class AidedTrackingLoop:
     cs_[2].Q = imag(L)
     aided_tl_update(&self._thisptr, cs_)
     return (self._thisptr.code_freq, self._thisptr.carr_freq)
+
+  def adjust_freq(self, corr):
+    aided_tl_adjust(&self._thisptr, corr)
 
   def to_dict(self):
     return self._thisptr

--- a/src/track.c
+++ b/src/track.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Swift Navigation Inc.
+ * Copyright (C) 2012,2016 Swift Navigation Inc.
  * Contact: Fergus Noble <fergus@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -372,6 +372,19 @@ void aided_tl_update(aided_tl_state_t *s, correlation_t cs[3])
   s->code_freq = simple_lf_update(&(s->code_filt), -code_error);
   if (s->carr_to_code) /* Optional carrier aiding of code loop */
     s->code_freq += s->carr_freq / s->carr_to_code;
+}
+
+/** Adjust carrier frequency.
+ *
+ * Applies the given correction to the internal state of the tracking loop.
+ *
+ * \param s The tracking loop state struct.
+ * \param err The correction in [Herz]
+ */
+void aided_tl_adjust(aided_tl_state_t *s, float err)
+{
+  s->carr_freq += err;
+  s->carr_filt.y = s->carr_freq;
 }
 
 /** Initialise a simple tracking loop.

--- a/tests/check_track.c
+++ b/tests/check_track.c
@@ -60,12 +60,31 @@ START_TEST(test_costas_discriminator)
 }
 END_TEST
 
+START_TEST(test_aided_tl_adjustment)
+{
+  aided_tl_state_t s;
+  aided_tl_init(&s, 50,    /* loop_freq [Hz] */
+                0,         /* Doppler on code_freq [Hz] */
+                1 /*code_bw*/, 0.7 /*code_zeta*/, 1 /*code_k*/,
+                1200 /*carr_to_code*/,
+                0 /* Doppler on carr_freq [Hz]*/,
+                13 /*carr_bw*/, 0.7 /*carr_zeta*/, 1 /*carr_k*/,
+                5 /*carr_freq_b1*/);
+  float carr_freq_prev = s.carr_freq;
+  float err = 15;
+  aided_tl_adjust(&s, err);
+  fail_unless((carr_freq_prev + err) == s.carr_freq,
+               "incorrect adjusment result");
+}
+END_TEST
+
 Suite* track_test_suite(void)
 {
   Suite *s = suite_create("Track");
 
   TCase *tc_core = tcase_create("Core");
   tcase_add_test(tc_core, test_costas_discriminator);
+  tcase_add_test(tc_core, test_aided_tl_adjustment);
   suite_add_tcase(s, tc_core);
 
   return s;


### PR DESCRIPTION
A new API 
void aided_tl_adjust(aided_tl_state_t *s, float err)
was added to adjust the tracking loop internal state based on the corrections from alias lock detectors.
The new API is going to be used in Peregrine alias lock detector simulations. The corresponding PR: 
https://github.com/swift-nav/peregrine/pull/51
